### PR TITLE
Revert "chore(deps-dev): bump textlint-rule-preset-japanese (#106)"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@types/react-dom": "^19.1.5",
         "@vitejs/plugin-react": "^4.3.4",
         "textlint-rule-preset-ja-technical-writing": "^10.0.1",
-        "textlint-rule-preset-japanese": "^10.0.4",
+        "textlint-rule-preset-japanese": "^10.0.3",
         "typescript": "^5.8.3",
         "vite": "^6.3.4"
       }
@@ -8546,14 +8546,13 @@
       }
     },
     "node_modules/textlint-rule-preset-japanese": {
-      "version": "10.0.4",
-      "resolved": "https://registry.npmjs.org/textlint-rule-preset-japanese/-/textlint-rule-preset-japanese-10.0.4.tgz",
-      "integrity": "sha512-xoQvGKhHCm2ZQqZAlSCgaeJI0cFSO4jleki1e8s/3FscuIr6SWcB3dB2tA+1TkOTd6X6MawC8Wah9+Z7+xaqrQ==",
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/textlint-rule-preset-japanese/-/textlint-rule-preset-japanese-10.0.3.tgz",
+      "integrity": "sha512-/h9ev8dBnRCgLqS4OPzXk5eTJNSqz7ezRNwuCLTlyN63leTSLCJQ62fyWX2hVRNebHczj5UqzVeJgn78kAnxmQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@textlint-rule/textlint-rule-no-invalid-control-character": "^3.0.0",
-        "@textlint/module-interop": "^14.0.0",
+        "@textlint-rule/textlint-rule-no-invalid-control-character": "^2.0.0",
+        "@textlint/module-interop": "^13.4.1",
         "textlint-rule-max-ten": "^5.0.0",
         "textlint-rule-no-double-negative-ja": "^2.0.1",
         "textlint-rule-no-doubled-conjunction": "^3.0.0",
@@ -8564,22 +8563,9 @@
         "textlint-rule-no-mix-dearu-desumasu": "^6.0.0",
         "textlint-rule-no-nfd": "^2.0.2",
         "textlint-rule-no-zero-width-spaces": "^1.0.1",
+        "textlint-rule-prh": "^5.2.0",
         "textlint-rule-sentence-length": "^5.0.0"
       }
-    },
-    "node_modules/textlint-rule-preset-japanese/node_modules/@textlint-rule/textlint-rule-no-invalid-control-character": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@textlint-rule/textlint-rule-no-invalid-control-character/-/textlint-rule-no-invalid-control-character-3.0.0.tgz",
-      "integrity": "sha512-2o9n4z49ntSPtJPlcJtxakyB4dAg2MKSvR9ZCZEHjye0ee27oWYzK6yHz2HjsXQqt9VeCwxNHDOIGIx2CQX0Dw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/textlint-rule-preset-japanese/node_modules/@textlint/module-interop": {
-      "version": "14.7.2",
-      "resolved": "https://registry.npmjs.org/@textlint/module-interop/-/module-interop-14.7.2.tgz",
-      "integrity": "sha512-rDQhFERa2+xMqhyrPFvAL9d5Tb4RpQGKQExwrezvtCTREh6Zsp/nKxtK0r6o0P9xn1+zq2sZHW9NZjpe7av3xw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/textlint-rule-preset-jtf-style": {
       "version": "2.3.14",
@@ -16522,13 +16508,13 @@
       }
     },
     "textlint-rule-preset-japanese": {
-      "version": "10.0.4",
-      "resolved": "https://registry.npmjs.org/textlint-rule-preset-japanese/-/textlint-rule-preset-japanese-10.0.4.tgz",
-      "integrity": "sha512-xoQvGKhHCm2ZQqZAlSCgaeJI0cFSO4jleki1e8s/3FscuIr6SWcB3dB2tA+1TkOTd6X6MawC8Wah9+Z7+xaqrQ==",
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/textlint-rule-preset-japanese/-/textlint-rule-preset-japanese-10.0.3.tgz",
+      "integrity": "sha512-/h9ev8dBnRCgLqS4OPzXk5eTJNSqz7ezRNwuCLTlyN63leTSLCJQ62fyWX2hVRNebHczj5UqzVeJgn78kAnxmQ==",
       "dev": true,
       "requires": {
-        "@textlint-rule/textlint-rule-no-invalid-control-character": "^3.0.0",
-        "@textlint/module-interop": "^14.0.0",
+        "@textlint-rule/textlint-rule-no-invalid-control-character": "^2.0.0",
+        "@textlint/module-interop": "^13.4.1",
         "textlint-rule-max-ten": "^5.0.0",
         "textlint-rule-no-double-negative-ja": "^2.0.1",
         "textlint-rule-no-doubled-conjunction": "^3.0.0",
@@ -16539,21 +16525,8 @@
         "textlint-rule-no-mix-dearu-desumasu": "^6.0.0",
         "textlint-rule-no-nfd": "^2.0.2",
         "textlint-rule-no-zero-width-spaces": "^1.0.1",
+        "textlint-rule-prh": "^5.2.0",
         "textlint-rule-sentence-length": "^5.0.0"
-      },
-      "dependencies": {
-        "@textlint-rule/textlint-rule-no-invalid-control-character": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@textlint-rule/textlint-rule-no-invalid-control-character/-/textlint-rule-no-invalid-control-character-3.0.0.tgz",
-          "integrity": "sha512-2o9n4z49ntSPtJPlcJtxakyB4dAg2MKSvR9ZCZEHjye0ee27oWYzK6yHz2HjsXQqt9VeCwxNHDOIGIx2CQX0Dw==",
-          "dev": true
-        },
-        "@textlint/module-interop": {
-          "version": "14.7.2",
-          "resolved": "https://registry.npmjs.org/@textlint/module-interop/-/module-interop-14.7.2.tgz",
-          "integrity": "sha512-rDQhFERa2+xMqhyrPFvAL9d5Tb4RpQGKQExwrezvtCTREh6Zsp/nKxtK0r6o0P9xn1+zq2sZHW9NZjpe7av3xw==",
-          "dev": true
-        }
       }
     },
     "textlint-rule-preset-jtf-style": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@types/react-dom": "^19.1.5",
     "@vitejs/plugin-react": "^4.3.4",
     "textlint-rule-preset-ja-technical-writing": "^10.0.1",
-    "textlint-rule-preset-japanese": "^10.0.4",
+    "textlint-rule-preset-japanese": "^10.0.3",
     "typescript": "^5.8.3",
     "vite": "^6.3.4"
   }


### PR DESCRIPTION
This reverts commit cefd4bce62651028319ec51c8cf4817e6dc6bc59.

```
> textlint-script-compiler --metadataName dev --metadataNamespace "https://example.com/" --metadataHomepage "https://example.com/" --mode development --output-dir public
[
  {
    moduleIdentifier: 'javascript/dynamic|/home/runner/work/pdf-linter/pdf-linter/node_modules/textlint-rule-preset-japanese/node_modules/@textlint/module-interop/module/src/index.js',
    moduleName: './node_modules/textlint-rule-preset-japanese/node_modules/@textlint/module-interop/module/src/index.js',
    loc: '1:0',
    message: "Module parse failed: 'import' and 'export' may appear only with 'sourceType: module' (1:0)\n" +
      'You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders\n' +
      '> export function moduleInterop(moduleExports) {\n' +
      '|     return moduleExports && moduleExports.__esModule ? moduleExports.default : moduleExports;\n' +
      '| }',
    moduleId: './node_modules/textlint-rule-preset-japanese/node_modules/@textlint/module-interop/module/src/index.js',
    moduleTrace: [ [Object], [Object] ],
    details: undefined,
    stack: "ModuleParseError: Module parse failed: 'import' and 'export' may appear only with 'sourceType: module' (1:0)\n" +
      'You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders\n' +
      '> export function moduleInterop(moduleExports) {\n' +
      '|     return moduleExports && moduleExports.__esModule ? moduleExports.default : moduleExports;\n' +
      '| }\n' +
      '    at handleParseError (/home/runner/work/pdf-linter/pdf-linter/node_modules/webpack/lib/NormalModule.js:1205:19)\n' +
      '    at /home/runner/work/pdf-linter/pdf-linter/node_modules/webpack/lib/NormalModule.js:1347:5\n' +
      '    at processResult (/home/runner/work/pdf-linter/pdf-linter/node_modules/webpack/lib/NormalModule.js:[96](https://github.com/otariidae/pdf-linter/actions/runs/15710121647/job/44528433086#step:5:97)8:11)\n' +
      '    at /home/runner/work/pdf-linter/pdf-linter/node_modules/webpack/lib/NormalModule.js:1066:5\n' +
      '    at /home/runner/work/pdf-linter/pdf-linter/node_modules/loader-runner/lib/LoaderRunner.js:406:3\n' +
      '    at iterateNormalLoaders (/home/runner/work/pdf-linter/pdf-linter/node_modules/loader-runner/lib/LoaderRunner.js:232:10)\n' +
      '    at /home/runner/work/pdf-linter/pdf-linter/node_modules/loader-runner/lib/LoaderRunner.js:223:4\n' +
      '    at /home/runner/work/pdf-linter/pdf-linter/node_modules/webpack/lib/NormalModule.js:1021:15\n' +
      '    at Array.eval (eval at create (/home/runner/work/pdf-linter/pdf-linter/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:12:1)\n' +
      '    at runCallbacks (/home/runner/work/pdf-linter/pdf-linter/node_modules/enhanced-resolve/lib/CachedInputFileSystem.js:45:15)',
    compilerPath: undefined
  }
]
[
  {
    moduleIdentifier: 'javascript/dynamic|/home/runner/work/pdf-linter/pdf-linter/node_modules/textlint-rule-preset-japanese/node_modules/@textlint/module-interop/module/src/index.js',
    moduleName: './node_modules/textlint-rule-preset-japanese/node_modules/@textlint/module-interop/module/src/index.js',
    loc: '1:0',
    message: "Module parse failed: 'import' and 'export' may appear only with 'sourceType: module' (1:0)\n" +
      'You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders\n' +
      '> export function moduleInterop(moduleExports) {\n' +
      '|     return moduleExports && moduleExports.__esModule ? moduleExports.default : moduleExports;\n' +
      '| }',
    moduleId: './node_modules/textlint-rule-preset-japanese/node_modules/@textlint/module-interop/module/src/index.js',
    moduleTrace: [ [Object], [Object] ],
    details: undefined,
    stack: "ModuleParseError: Module parse failed: 'import' and 'export' may appear only with 'sourceType: module' (1:0)\n" +
      'You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders\n' +
      '> export function moduleInterop(moduleExports) {\n' +
      '|     return moduleExports && moduleExports.__esModule ? moduleExports.default : moduleExports;\n' +
      '| }\n' +
      '    at handleParseError (/home/runner/work/pdf-linter/pdf-linter/node_modules/webpack/lib/NormalModule.js:1205:19)\n' +
      '    at /home/runner/work/pdf-linter/pdf-linter/node_modules/webpack/lib/NormalModule.js:1347:5\n' +
      '    at processResult (/home/runner/work/pdf-linter/pdf-linter/node_modules/webpack/lib/NormalModule.js:968:11)\n' +
      '    at /home/runner/work/pdf-linter/pdf-linter/node_modules/webpack/lib/NormalModule.js:1066:5\n' +
      '    at /home/runner/work/pdf-linter/pdf-linter/node_modules/loader-runner/lib/LoaderRunner.js:406:3\n' +
      '    at iterateNormalLoaders (/home/runner/work/pdf-linter/pdf-linter/node_modules/loader-runner/lib/LoaderRunner.js:232:10)\n' +
      '    at /home/runner/work/pdf-linter/pdf-linter/node_modules/loader-runner/lib/LoaderRunner.js:223:4\n' +
      '    at /home/runner/work/pdf-linter/pdf-linter/node_modules/webpack/lib/NormalModule.js:[102](https://github.com/otariidae/pdf-linter/actions/runs/15710121647/job/44528433086#step:5:103)1:15\n' +
      '    at Array.eval (eval at create (/home/runner/work/pdf-linter/pdf-linter/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:12:1)\n' +
      '    at runCallbacks (/home/runner/work/pdf-linter/pdf-linter/node_modules/enhanced-resolve/lib/CachedInputFileSystem.js:45:15)',
    compilerPath: undefined
  }
]
Error: Process completed with exit code 1.
```